### PR TITLE
Allowing getResourceId to be string

### DIFF
--- a/dist/acl.js
+++ b/dist/acl.js
@@ -347,6 +347,9 @@ angular.module('ng-acl').service('AclService', ["AclRegistryService", function (
         if (resource instanceof Object && typeof resource.getResourceId === 'function') {
             resource = resource.getResourceId();
         }
+        else if (resource instanceof Object && typeof resource.getResourceId === 'string'){
+            resource = resource.getResourceId;
+        }
 
         return _resources[resource].id;
     };
@@ -369,6 +372,9 @@ angular.module('ng-acl').service('AclService', ["AclRegistryService", function (
     this.hasResource = function (resource) {
         if (resource instanceof Object && typeof resource.getResourceId === 'function') {
             resource = resource.getResourceId();
+        }
+        else if (resource instanceof Object && typeof resource.getResourceId === 'string'){
+            resource = resource.getResourceId;
         }
 
         return _resources[resource] !== undefined;

--- a/src/acl-service.js
+++ b/src/acl-service.js
@@ -346,6 +346,9 @@ angular.module('ng-acl').service('AclService', function (AclRegistryService) {
         if (resource instanceof Object && typeof resource.getResourceId === 'function') {
             resource = resource.getResourceId();
         }
+        else if (resource instanceof Object && typeof resource.getResourceId === 'string'){
+            resource = resource.getResourceId;
+        }
 
         return _resources[resource].id;
     };
@@ -368,6 +371,9 @@ angular.module('ng-acl').service('AclService', function (AclRegistryService) {
     this.hasResource = function (resource) {
         if (resource instanceof Object && typeof resource.getResourceId === 'function') {
             resource = resource.getResourceId();
+        }
+        else if (resource instanceof Object && typeof resource.getResourceId === 'string'){
+            resource = resource.getResourceId;
         }
 
         return _resources[resource] !== undefined;


### PR DESCRIPTION
Reason: i just wanted getResourceId to be generated on backend side.
